### PR TITLE
Add initial scripts for preparing the provisioning host

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -ex
+
+source logging.sh
+
+# FIXME: include checks from common.sh, see https://github.com/openshift-metal3/dev-scripts/issues/727
+
+# Update to latest packages first
+sudo yum -y update
+
+# Note: we're leaving SELinux in enforcing mode
+# Note: we're not enabling EPEL
+
+# Install required packages
+sudo yum -y install \
+  curl \
+  nmap \
+  jq
+
+sudo yum -y install \
+  libvirt \
+  libvirt-daemon-kvm
+
+# Install oc client
+oc_version=4.2
+oc_tools_dir=$HOME/oc-${oc_version}
+oc_tools_local_file=openshift-client-${oc_version}.tar.gz
+oc_date=0
+if which oc 2>&1 >/dev/null ; then
+    oc_date=$(date -d $(oc version -o json  | jq -r '.clientVersion.buildDate') +%s)
+fi
+if [ ! -f ${oc_tools_dir}/${oc_tools_local_file} ] || [ $oc_date -lt 1559308936 ]; then
+  mkdir -p ${oc_tools_dir}
+  cd ${oc_tools_dir}
+  wget https://mirror.openshift.com/pub/openshift-v4/clients/oc/${oc_version}/linux/oc.tar.gz -O ${oc_tools_local_file}
+  tar xvzf ${oc_tools_local_file}
+  sudo cp oc /usr/local/bin/
+fi

--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -15,7 +15,8 @@ sudo yum -y update
 sudo yum -y install \
   curl \
   nmap \
-  jq
+  jq \
+  wget
 
 sudo yum -y install \
   libvirt \

--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -18,6 +18,10 @@ sudo yum -y install \
   jq \
   wget
 
+# FIXME: using deprecated network-scripts needed for NM_CONTROLLED=no
+# interfaces on RHEL-8
+sudo yum install -y network-scripts
+
 sudo yum -y install \
   libvirt \
   libvirt-daemon-kvm

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -xe
+
+source logging.sh
+source common.sh
+
+# FIXME: we don't generate a user SSH key - check for one?
+
+# Restart libvirtd service to get the new group membership loaded
+if ! id $USER | grep -q libvirt; then
+  sudo usermod -a -G "libvirt" $USER
+  sudo systemctl restart libvirtd
+fi
+
+# As per https://github.com/openshift/installer/blob/master/docs/dev/libvirt-howto.md#configure-default-libvirt-storage-pool
+# Usually virt-manager/virt-install creates this: https://www.redhat.com/archives/libvir-list/2008-August/msg00179.html
+if ! virsh pool-uuid default > /dev/null 2>&1 ; then
+    virsh pool-define /dev/stdin <<EOF
+<pool type='dir'>
+  <name>default</name>
+  <target>
+    <path>/var/lib/libvirt/images</path>
+  </target>
+</pool>
+EOF
+    virsh pool-start default
+    virsh pool-autostart default
+fi
+
+# Create the provisioning bridge
+if ! virsh net-uuid provisioning > /dev/null 2>&1 ; then
+    virsh net-define /dev/stdin <<EOF
+<network>
+  <name>provisioning</name>
+  <bridge name='provisioning'/>
+  <forward mode='bridge'/>
+</network>
+EOF
+    virsh net-start provisioning
+    virsh net-autostart provisioning
+fi
+
+# Adding an IP address in the libvirt definition for this network results in
+# dnsmasq being run, we don't want that as we have our own dnsmasq, so set
+# the IP address here
+if [ ! -e /etc/sysconfig/network-scripts/ifcfg-provisioning ] ; then
+    echo -e "DEVICE=provisioning\nTYPE=Bridge\nONBOOT=yes\nNM_CONTROLLED=no\nBOOTPROTO=static\nIPADDR=172.22.0.1\nNETMASK=255.255.255.0\nZONE=libvirt" | sudo dd of=/etc/sysconfig/network-scripts/ifcfg-provisioning
+fi
+sudo ifdown provisioning || true
+sudo ifup provisioning
+
+# Need to pass the provision interface for bare metal
+if [ "$PRO_IF" ]; then
+    echo -e "DEVICE=$PRO_IF\nTYPE=Ethernet\nONBOOT=yes\nNM_CONTROLLED=no\nBRIDGE=provisioning" | sudo dd of=/etc/sysconfig/network-scripts/ifcfg-$PRO_IF
+    sudo ifdown $PRO_IF || true
+    sudo ifup $PRO_IF
+fi
+
+# Create the baremetal bridge
+# FIXME: is DHCP and DNS configuration needed?
+if ! virsh net-uuid baremetal > /dev/null 2>&1 ; then
+    virsh net-define /dev/stdin <<EOF
+<network>
+  <name>baremetal</name>
+  <bridge name='baremetal'/>
+  <forward mode='bridge'/>
+</network>
+EOF
+    virsh net-start baremetal
+    virsh net-autostart baremetal
+fi
+
+if [ ! -e /etc/sysconfig/network-scripts/ifcfg-baremetal ] ; then
+    echo -e "DEVICE=baremetal\nTYPE=Bridge\nONBOOT=yes\nNM_CONTROLLED=no\nZONE=libvirt" | sudo dd of=/etc/sysconfig/network-scripts/ifcfg-baremetal
+fi
+sudo ifdown baremetal || true
+sudo ifup baremetal
+
+# Add the internal interface to it if requests, this may also be the interface providing
+# external access so we need to make sure we maintain dhcp config if its available
+if [ "$INT_IF" ]; then
+    echo -e "DEVICE=$INT_IF\nTYPE=Ethernet\nONBOOT=yes\nNM_CONTROLLED=no\nBRIDGE=baremetal" | sudo dd of=/etc/sysconfig/network-scripts/ifcfg-$INT_IF
+    if sudo nmap --script broadcast-dhcp-discover -e $INT_IF | grep "IP Offered" ; then
+        grep -q BOOTPROTO /etc/sysconfig/network-scripts/ifcfg-baremetal || (echo -e "\nBOOTPROTO=dhcp\n" | sudo tee -a /etc/sysconfig/network-scripts/ifcfg-baremetal)
+    fi
+    sudo systemctl restart network
+fi
+
+# If there were modifications to the /etc/sysconfig/network-scripts/ifcfg-*
+# files, it is required to enable the network service
+sudo systemctl enable network

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -27,6 +27,9 @@ EOF
     virsh pool-autostart default
 fi
 
+# FIXME: is this needed?
+ZONE="\nZONE=libvirt"
+
 # Create the provisioning bridge
 if ! virsh net-uuid provisioning > /dev/null 2>&1 ; then
     virsh net-define /dev/stdin <<EOF
@@ -44,7 +47,7 @@ fi
 # dnsmasq being run, we don't want that as we have our own dnsmasq, so set
 # the IP address here
 if [ ! -e /etc/sysconfig/network-scripts/ifcfg-provisioning ] ; then
-    echo -e "DEVICE=provisioning\nTYPE=Bridge\nONBOOT=yes\nNM_CONTROLLED=no\nBOOTPROTO=static\nIPADDR=172.22.0.1\nNETMASK=255.255.255.0\nZONE=libvirt" | sudo dd of=/etc/sysconfig/network-scripts/ifcfg-provisioning
+    echo -e "DEVICE=provisioning\nTYPE=Bridge\nONBOOT=yes\nNM_CONTROLLED=no\nBOOTPROTO=static\nIPADDR=172.22.0.1\nNETMASK=255.255.255.0${ZONE}" | sudo dd of=/etc/sysconfig/network-scripts/ifcfg-provisioning
 fi
 sudo ifdown provisioning || true
 sudo ifup provisioning
@@ -71,7 +74,7 @@ EOF
 fi
 
 if [ ! -e /etc/sysconfig/network-scripts/ifcfg-baremetal ] ; then
-    echo -e "DEVICE=baremetal\nTYPE=Bridge\nONBOOT=yes\nNM_CONTROLLED=no\nZONE=libvirt" | sudo dd of=/etc/sysconfig/network-scripts/ifcfg-baremetal
+    echo -e "DEVICE=baremetal\nTYPE=Bridge\nONBOOT=yes\nNM_CONTROLLED=no${ZONE}" | sudo dd of=/etc/sysconfig/network-scripts/ifcfg-baremetal
 fi
 sudo ifdown baremetal || true
 sudo ifup baremetal

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -60,7 +60,6 @@ if [ "$PRO_IF" ]; then
 fi
 
 # Create the baremetal bridge
-# FIXME: is DHCP and DNS configuration needed?
 if ! virsh net-uuid baremetal > /dev/null 2>&1 ; then
     virsh net-define /dev/stdin <<EOF
 <network>

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: default all requirements configure
+default: requirements configure
+
+all: default
+
+requirements:
+	./01_install_requirements.sh
+
+configure:
+	./02_configure_host.sh
+
+clean: host_cleanup
+
+host_cleanup:
+	./host_cleanup.sh
+
+bell:
+	@echo "Done!" $$'\a'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,31 @@
 # install-scripts
 Installation scripts for OpenShift KNI clusters
 
+## Provisioning Host Setup
+
+The provisioning host must be a RHEL-8 machine.
+
+Make a copy of `config_example.sh` and set the required variables in
+there.
+
+To install some required packages and the `oc` client:
+
+```sh
+make requirements
+```
+
+Note:
+
+1. This ensures that a recent 4.2 build of `oc` is installed. The
+   minimum required version is hardcoded in the script.
+
+To configure libvirt, and prepare the `provisioning` and `baremetal`
+bridges:
+
+```sh
+make configure
+```
+
 ## Continer Native Virtualization (CNV)
 The installation of CNV related operators is managed by a *meta operator*
 called the [HyperConverged Cluster Operator](https://github.com/kubevirt/hyperconverged-cluster-operator) (HCO).

--- a/common.sh
+++ b/common.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+USER=`whoami`
+
+# Get variables from the config file
+if [ -z "${CONFIG:-}" ]; then
+    # See if there's a config_$USER.sh in the SCRIPTDIR
+    if [ -f ${SCRIPTDIR}/config_${USER}.sh ]; then
+        echo "Using CONFIG ${SCRIPTDIR}/config_${USER}.sh"
+        CONFIG="${SCRIPTDIR}/config_${USER}.sh"
+    else
+        echo "Please run with a configuration environment set."
+        echo "eg CONFIG=config_example.sh ./01_all_in_one.sh"
+        exit 1
+    fi
+fi
+source $CONFIG
+
+# Connect to system libvirt
+export LIBVIRT_DEFAULT_URI=qemu:///system
+if [ "$USER" != "root" -a "${XDG_RUNTIME_DIR:-}" == "/run/user/0" ] ; then
+    echo "Please use a non-root user, WITH a login shell (e.g. su - USER)"
+    exit 1
+fi
+
+# Check if sudo privileges without password
+if ! sudo -n uptime &> /dev/null ; then
+  echo "sudo without password is required"
+  exit 1
+fi
+
+# Check OS
+VER=$(awk -F= '/^VERSION_ID=/ { print $2 }' /etc/os-release | tr -d '"' | cut -f1 -d'.')
+if [[ $(awk -F= '/^ID=/ { print $2 }' /etc/os-release | tr -d '"') != "rhel" ]] || [[ ${VER} -ne 8 ]]; then
+  echo "Unsupported OS - RHEL 8 required"
+  exit 1
+fi
+
+# avoid "-z $PULL_SECRET" to ensure the secret is not logged
+if [ ${#PULL_SECRET} = 0 ]; then
+  echo "No valid PULL_SECRET set in ${CONFIG}"
+  echo "Get a valid pull secret (json string) from https://cloud.openshift.com/clusters/install#pull-secret"
+  exit 1
+fi

--- a/config_example.sh
+++ b/config_example.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Get a valid pull secret (json string) from
+# You can get this secret from https://cloud.openshift.com/clusters/install#pull-secret
+set +x
+export PULL_SECRET=''
+set -x
+
+# Set to the interface used by the provisioning bridge
+#PRO_IF="em1"
+
+# Set to the interface used by the baremetal bridge
+#INT_IF="em2"
+

--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -3,3 +3,21 @@ set -x
 
 source logging.sh
 source common.sh
+
+if virsh net-uuid baremetal > /dev/null 2>&1 ; then
+    virsh net-destroy baremetal
+    virsh net-undefine baremetal
+fi
+
+sudo ifdown baremetal || true
+sudo ip link delete baremetal || true
+sudo rm -f /etc/sysconfig/network-scripts/ifcfg-baremetal
+
+if virsh net-uuid provisioning > /dev/null 2>&1 ; then
+    virsh net-destroy provisioning
+    virsh net-undefine provisioning
+fi
+
+sudo ifdown provisioning || true
+sudo ip link delete provisioning || true
+sudo rm -f /etc/sysconfig/network-scripts/ifcfg-provisioning

--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -x
+
+source logging.sh
+source common.sh

--- a/logging.sh
+++ b/logging.sh
@@ -1,0 +1,9 @@
+# Log output automatically
+LOGDIR="$(dirname $0)/logs"
+if [ ! -d "$LOGDIR" ]; then
+    mkdir -p "$LOGDIR"
+fi
+LOGFILE="$LOGDIR/$(basename $0 .sh)-$(date +%F-%H%M%S).log"
+echo "Logging to $LOGFILE"
+# Set fd 1 and 2 to write to the log file
+exec 1> >( tee "${LOGFILE}" ) 2>&1


### PR DESCRIPTION
Takes a small subset of what we do in dev-scripts - supporting only RHEL8 and "real bare metal"

Also keep dependencies to a minimum - so e.g. avoid using the tripleo-ansible playbooks just to create libvirt networks