### PR TITLE
cnv: fixes issue #18

### DIFF
--- a/CNV/99-brext-master.yaml
+++ b/CNV/99-brext-master.yaml
@@ -1,0 +1,22 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 99-brext-master
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,${interface_content}
+        filesystem: root
+        mode: 0644
+        path: /etc/sysconfig/network-scripts/ifcfg-${interface}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,${bridge_content}
+        filesystem: root
+        mode: 0644
+        path: /etc/sysconfig/network-scripts/ifcfg-${bridge}

--- a/CNV/README.md
+++ b/CNV/README.md
@@ -2,9 +2,9 @@
 
 ## What does it do
 
-The script [deploy-cnv.sh](deploy-cnv.sh) deploys *CNV 2.0* through [OLM](https://github.com/operator-framework/operator-lifecycle-manager), meaning:
+The script [deploy-cnv.sh](deploy-cnv.sh) deploys *CNV 2.0* through [OLM](https://github.com/operator-framework/operator-lifecycle-manager), meaning that:
 
-* Creates a resource *Subscription* which triggers the deployment of all the operators that are required for CNV to work
+* It creates a resource *Subscription* which triggers the deployment of all the operators that are required for CNV to work
 * Waits for the operator pods to be ready
 * Creates the custom resource *HyperConverged*, which makes the operators to deploy all their components and register the provided resources for them to be available (apiservices, CRDs, ...)
-* Finally, waits for the new pods to be ready and CNV is ready to be used
+* Finally, waits for the new pods to be ready and CNV to be ready to be used

--- a/CNV/deploy-bridge.sh
+++ b/CNV/deploy-bridge.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+export bridge="${bridge:-brext}"
+
+set -e
+
+echo "Deploying Bridge ${bridge}..."
+  
+FIRST_MASTER=$(oc get node -o custom-columns=IP:.status.addresses[0].address --no-headers | head -1)
+export interface=$(ssh -q core@$FIRST_MASTER "ip r | grep default | grep -Po '(?<=dev )(\S+)'")
+if [ "$interface" == "" ] ; then
+  echo "Issue detecting interface to use! Leaving..."
+  exit 1
+fi
+
+if [ "$interface" != "$bridge" ] ; then
+  echo "Using interface $interface"
+  export interface_content=$(envsubst < ifcfg-interface | base64 -w0)
+  export bridge_content=$(envsubst < ifcfg-bridge | base64 -w0)
+  envsubst < 99-brext-master.yaml | oc create -f -
+  echo "Waiting 30s for machine-config change to get applied..."
+  # This sleep is required because the machine-config changes are not immediate
+  sleep 30
+  echo "Waiting for bridge to be deployed on all the nodes..."
+  # The while is required because in the process of rebooting the hosts, the
+  # oc wait connection is lost a few times, which is normal
+  while ! oc wait mcp/master --for condition=updated --timeout 900s ; do sleep 1 ; done
+  echo "Done installing Bridge!"
+else
+  echo "Bridge already there!"
+fi

--- a/CNV/deploy-cnv.sh
+++ b/CNV/deploy-cnv.sh
@@ -2,7 +2,6 @@
 
 OPERATORS_NAMESPACE="openshift-operators"
 LINUX_BRIDGE_NAMESPACE="linux-bridge"
-KWEB_UI_NAMESPACE="kubevirt-web-ui"
 
 set -e
 
@@ -30,11 +29,9 @@ done
 oc wait --for condition=ready pod -l name=hyperconverged-cluster-operator -n ${OPERATORS_NAMESPACE} --timeout=2400s
 oc wait --for condition=ready pod -l kubevirt.io=virt-operator -n ${OPERATORS_NAMESPACE} --timeout=2400s
 oc wait --for condition=ready pod -l name=cdi-operator -n ${OPERATORS_NAMESPACE} --timeout=2400s
-oc wait --for condition=ready pod -l name=kubevirt-web-ui-operator -n ${OPERATORS_NAMESPACE} --timeout=2400s
 oc wait --for condition=ready pod -l name=cluster-network-addons-operator -n ${OPERATORS_NAMESPACE} --timeout=2400s
 oc wait --for condition=ready pod -l name=kubevirt-ssp-operator -n ${OPERATORS_NAMESPACE} --timeout=2400s
 oc wait --for condition=ready pod -l name=node-maintenance-operator -n ${OPERATORS_NAMESPACE} --timeout=2400s
-
 
 echo "Launching CNV..."
 cat <<EOF | oc create -f -
@@ -83,17 +80,10 @@ done
 oc wait --for condition=ready pod -l app=bridge-marker -n ${LINUX_BRIDGE_NAMESPACE} --timeout=2400s
 oc wait --for condition=ready pod -l app=cni-plugins -n ${LINUX_BRIDGE_NAMESPACE} --timeout=2400s
 
-while [ "x" == "x$(oc get pods -l app=kubevirt-web-ui -n ${KWEB_UI_NAMESPACE} 2> /dev/null)" ]; do
-    sleep 10
-done
-
-oc wait --for condition=ready pod -l app=kubevirt-web-ui -n ${KWEB_UI_NAMESPACE} --timeout=2400s
-
 while [ "x" == "x$(oc get pods -l app=kubevirt-node-labeller -n ${OPERATORS_NAMESPACE} 2> /dev/null)" ]; do
     sleep 10
 done
 
 oc wait --for condition=ready pod -l app=kubevirt-node-labeller -n ${OPERATORS_NAMESPACE} --timeout=2400s
-
 
 echo "Done installing CNV!"

--- a/CNV/ifcfg-bridge
+++ b/CNV/ifcfg-bridge
@@ -1,0 +1,8 @@
+DEVICE=${bridge}
+NAME=${bridge}
+TYPE=Bridge
+ONBOOT=yes
+NM_CONTROLLED=yes
+BOOTPROTO=dhcp
+BRIDGING_OPTS=vlan_filtering=1
+BRIDGE_VLANS="1 pvid untagged,20,300-400 untagged"

--- a/CNV/ifcfg-interface
+++ b/CNV/ifcfg-interface
@@ -1,0 +1,5 @@
+DEVICE=${interface}
+BRIDGE=${bridge}
+ONBOOT=yes
+NM_CONTROLLED=yes
+BOOTPROTO=none


### PR DESCRIPTION
fixes https://github.com/openshift-kni/install-scripts/issues/18
- incorporate a script for bridge handling by detecting which nic to build the bridge on top of, and making the bridge name configurable
- wait for this bridge to be properly ready on each master prior to deploying cnv
- remove kubevirt web ui check as the relevant code lives in the openshift console

this is currently done without nmstate