### PR TITLE
Make it easier to drop the release override.

### DIFF
--- a/03_create_cluster.sh
+++ b/03_create_cluster.sh
@@ -4,7 +4,7 @@ set -xe
 source logging.sh
 source common.sh
 
-export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE:-registry.svc.ci.openshift.org/ocp/release:4.2}"
+export OPENSHIFT_RELEASE_IMAGE="${OPENSHIFT_RELEASE_IMAGE:-registry.svc.ci.openshift.org/ocp/release:4.2}"
 
 function extract_installer() {
     local release_image
@@ -19,7 +19,7 @@ function extract_installer() {
     echo "${PULL_SECRET}" > "${pullsecret_file}"
     # FIXME: Find the pullspec for baremetal-installer image and extract the image, until
     # https://github.com/openshift/oc/pull/57 is merged
-    baremetal_image=$(oc adm release info --registry-config "${pullsecret_file}" $OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE -o json | jq -r '.references.spec.tags[] | select(.name == "baremetal-installer") | .from.name')
+    baremetal_image=$(oc adm release info --registry-config "${pullsecret_file}" $OPENSHIFT_RELEASE_IMAGE -o json | jq -r '.references.spec.tags[] | select(.name == "baremetal-installer") | .from.name')
     oc image extract --registry-config "${pullsecret_file}" $baremetal_image --path usr/bin/openshift-install:${extract_dir}
 
     chmod 755 "${extract_dir}/openshift-install"
@@ -38,7 +38,7 @@ if [ ! -f install-config.yaml ] ; then
 fi
 
 # Do some PULL_SECRET sanity checking
-if [[ "${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE}" == *"registry.svc.ci.openshift.org"* ]]; then
+if [[ "${OPENSHIFT_RELEASE_IMAGE}" == *"registry.svc.ci.openshift.org"* ]]; then
     if [[ "${PULL_SECRET}" != *"registry.svc.ci.openshift.org"* ]]; then
         echo "Please get a valid pull secret for registry.svc.ci.openshift.org."
         exit 1
@@ -50,9 +50,7 @@ if [[ "${PULL_SECRET}" != *"cloud.openshift.com"* ]]; then
 fi
 
 mkdir -p ocp
-extract_installer "${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE}" ocp/
+extract_installer "${OPENSHIFT_RELEASE_IMAGE}" ocp/
 cp install-config.yaml ocp/
-${OPENSHIFT_INSTALLER} --dir ocp create manifests
-# TODO - Add custom install time manifests here:
-#  - https://github.com/openshift-kni/install-scripts/issues/30
-${OPENSHIFT_INSTALLER} --dir ocp create cluster
+# FIXME: remove OPENSHIFT_INSTALL_RELASE_IMAGE_OVERRIDE when openshift/oc#57 merges
+OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=$OPENSHIFT_RELEASE_IMAGE ${OPENSHIFT_INSTALLER} --dir ocp create cluster


### PR DESCRIPTION
This is based on feedback from #35.

The release override can be dropped once the oc changes merge that
allow us to extract the installer with the release image set
appropriately.  Move the release override var to one spot where it'll
easily be removed when the time comes.

Also drop "create manifests", as we don't use it yet, and it's unclear
if we'll keep it at all.