### PR TITLE
Install genisoimage to make Ironic configdrives

### DIFF
--- a/OpenShift/01_install_requirements.sh
+++ b/OpenShift/01_install_requirements.sh
@@ -14,6 +14,7 @@ sudo yum -y update
 # Install required packages
 sudo yum -y install \
   curl \
+  genisoimage \
   nmap \
   jq \
   wget


### PR DESCRIPTION
The terraform provider uses mkisofs to create the config drive iso, this
is brought in implicitly in dev-scripts via the openstack ironic client.

fixes #38