### PR TITLE
Add Makefiles to CNV and OCS directories

### DIFF
--- a/CNV/Makefile
+++ b/CNV/Makefile
@@ -1,0 +1,5 @@
+.PHONY: all run
+all: run
+
+run:
+	./deploy-cnv.sh

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ OpenShift:
 	pushd Openshift; make; popd
 
 OCS: OpenShift
-	pushd OCS; ./customize-ocs.sh; popd
+	pushd OCS; make; popd
 
 CNV: OpenShift
-	pushd CNV; ./deploy-cnv.sh; popd
+	pushd CNV; make; popd
 
 
 bell:

--- a/OCS/Makefile
+++ b/OCS/Makefile
@@ -1,0 +1,5 @@
+.PHONY: all run
+all: run
+
+run:
+	./customize-ocs.sh


### PR DESCRIPTION
It is much easier from a CI perspective to have common make targets to call to deploy the various components of the appliance. Otherwise, changes to script names (such as the PR to add CNV-2.1) would break CI

This is following a similar mindset to https://github.com/openshift-kni/install-scripts/pull/41

Signed-off-by: Johnny Bieren <jbieren@redhat.com>