### PR TITLE
Fix race condition in `oc` by disabling unpigz

### DIFF
--- a/OpenShift/03_create_cluster.sh
+++ b/OpenShift/03_create_cluster.sh
@@ -7,6 +7,12 @@ source common.sh
 export OPENSHIFT_RELEASE_IMAGE="${OPENSHIFT_RELEASE_IMAGE:-registry.svc.ci.openshift.org/ocp/release:4.2}"
 LOGLEVEL="${LOGLEVEL:-info}"
 
+# Do not use unpigz to extract images due to race condition in vendored
+# docker code that oc uses.
+# See: https://github.com/openshift/oc/issues/58,
+#      https://github.com/moby/moby/issues/39859
+export MOBY_DISABLE_PIGZ=true
+
 function extract_command() {
     local release_image
     local cmd


### PR DESCRIPTION
This sets an environment variable that makes `oc` not use unpigz to
decompress docker image layers but instead use the slower gzip
library in golang. There is a race condition that causes `oc` to
sometimes panic.

Similar to https://github.com/openshift-metal3/dev-scripts/pull/790

Work around for https://github.com/openshift/oc/issues/58 until a proper fix makes it into docker and `oc`.
