### PR TITLE
Updating the version

### DIFF
--- a/OCS/cluster.yaml
+++ b/OCS/cluster.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-storage
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.2-20190722 # TODO Update to image we decide on
+    image: ceph/ceph:v14.2.2-20190830
     allowUnsupported: false
   dataDirHostPath: /var/lib/rook
   mon:
@@ -37,7 +37,7 @@ spec:
     osd:
       requests:
           cpu: "2"
-          memory: "4Gi"
+          memory: "6Gi"
       limits:
         cpu: "2"
         memory: "6Gi"


### PR DESCRIPTION
This is to update the Ceph build. The previous build had[1], which would
cause OOMKill to destroy the OSD pods.

[1] https://tracker.ceph.com/issues/41037