### PR TITLE
cnv: add option to specify quay token directly

### DIFF
--- a/CNV/cnv-2.1.0.sh
+++ b/CNV/cnv-2.1.0.sh
@@ -25,17 +25,18 @@ if [ "${CLUSTER}" == "KUBERNETES" ]; then
     MARKETPLACE_NAMESPACE="marketplace"
 fi
 
-if [ -z "${QUAY_USERNAME}" ]; then
-    echo "QUAY_USERNAME"
-    read QUAY_USERNAME
-fi
+if [ -z "${QUAY_TOKEN}" ]; then
+    if [ -z "${QUAY_USERNAME}" ]; then
+        echo "QUAY_USERNAME"
+        read QUAY_USERNAME
+    fi
 
-if [ -z "${QUAY_PASSWORD}" ]; then
-    echo "QUAY_PASSWORD"
-    read -s QUAY_PASSWORD
-fi
+    if [ -z "${QUAY_PASSWORD}" ]; then
+        echo "QUAY_PASSWORD"
+        read -s QUAY_PASSWORD
+    fi
 
-TOKEN=$(curl -sH "Content-Type: application/json" -XPOST https://quay.io/cnr/api/v1/users/login -d '
+    QUAY_TOKEN=$(curl -sH "Content-Type: application/json" -XPOST https://quay.io/cnr/api/v1/users/login -d '
 {
     "user": {
         "username": "'"${QUAY_USERNAME}"'",
@@ -43,10 +44,11 @@ TOKEN=$(curl -sH "Content-Type: application/json" -XPOST https://quay.io/cnr/api
     }
 }' | jq -r '.token')
 
-echo $TOKEN
-if [ "${TOKEN}" == "null" ]; then
-   echo "TOKEN was 'null'.  Did you enter the correct quay Username & Password?"
-   exit 1
+    echo "QUAY_TOKEN=$QUAY_TOKEN"
+    if [ "${$QUAY_TOKEN}" == "null" ]; then
+       echo "QUAY_TOKEN was 'null'.  Did you enter the correct quay Username & Password?"
+       exit 1
+    fi
 fi
 
 echo "Creating registry secret"
@@ -58,7 +60,7 @@ metadata:
   namespace: "${MARKETPLACE_NAMESPACE}"
 type: Opaque
 stringData:
-      token: "$TOKEN"
+      token: "$QUAY_TOKEN"
 EOF
 
 echo "Creating OperatorGroup"


### PR DESCRIPTION
In case user already has a token, there is no need to specify username
and password to get a token.

Signed-off-by: Lukas Bednar <lbednar@redhat.com>