### PR TITLE
Run all targets by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,7 @@
 
 .PHONY: default all OpenShift OCS CNV prep
 
-default: OpenShift bell
-
-all: OpenShift OCS CNV bell
+default: OpenShift OCS CNV bell
 
 prep:
 	pushd OpenShift; make pre_install; popd


### PR DESCRIPTION
To allow running inidividual targets like make OpenShift/CNV/OCS. Currently running make CNV/OCS on top of an already deployed OpenShift cluster doesn't work as it triggers the installation of an additional cluster.

Fixes: #81