### PR TITLE
Remove OpenShift dependency from CNV and OCS targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ prep:
 OpenShift:
 	set -e; pushd OpenShift; make; popd
 
-OCS: OpenShift
+OCS:
 	set -e; pushd OCS; make; popd
 
-CNV: OpenShift
+CNV:
 	set -e; pushd CNV; make; popd
 
 bell:


### PR DESCRIPTION
PR#82 missed removing the OpenShift dependency from OCS and CNV targets. This change is removing the dependency allowing to run individual targets as follows:

```shell
make => run all targets
make OpenShift => run OpenShift target only
make OCS => run OCS target only
make CNV => run CNV target only
```