### PR TITLE
Set Quay credentials example in config_example.sh

### DIFF
--- a/CNV/cnv-2.1.0.sh
+++ b/CNV/cnv-2.1.0.sh
@@ -3,6 +3,7 @@
 set -ex
 
 export KUBECONFIG=${KUBECONFIG:-../OpenShift/ocp/auth/kubeconfig}
+source ../OpenShift/config_${USER}.sh
 
 globalNamespace=`oc -n openshift-operator-lifecycle-manager get deployments catalog-operator -o jsonpath='{.spec.template.spec.containers[].args[1]}'`
 echo "Global Namespace: ${globalNamespace}"

--- a/OpenShift/config_example.sh
+++ b/OpenShift/config_example.sh
@@ -17,3 +17,7 @@ set -x
 
 # Set loglevel for OpenShift installation
 #LOGLEVEL=debug
+
+# Set Quay credentials for CNV pre-release access
+# QUAY_USERNAME="user"
+# QUAY_PASSWORD="pass"


### PR DESCRIPTION
Quay credentials are requried when deploying CNV 2.1. This change is adding them in config_example.sh and makes them available when running the CNV installation script.