### PR TITLE
Cache

### DIFF
--- a/OpenShift/01_install_requirements.sh
+++ b/OpenShift/01_install_requirements.sh
@@ -18,6 +18,7 @@ sudo yum -y install \
   nmap \
   jq \
   tar \
+  podman \
   wget
 
 # FIXME: using deprecated network-scripts needed for NM_CONTROLLED=no

--- a/OpenShift/03_create_cluster.sh
+++ b/OpenShift/03_create_cluster.sh
@@ -103,6 +103,11 @@ if [[ "${PULL_SECRET}" != *"cloud.openshift.com"* ]]; then
     exit 1
 fi
 
+#To determine the image url, need the following extracted.
+mkdir -p ocp
+extract_oc ${OPENSHIFT_RELEASE_IMAGE}
+extract_installer "${OPENSHIFT_RELEASE_IMAGE}" ocp/
+
 # Discover and set RHCOS_IMAGE_URL
 rhcos_image_url
 
@@ -112,10 +117,8 @@ then
 fi
 
 
-mkdir -p ocp
-extract_oc ${OPENSHIFT_RELEASE_IMAGE}
-extract_installer "${OPENSHIFT_RELEASE_IMAGE}" ocp/
 cp install-config.yaml ocp/
+get_provinsion_if
 ./gen_metal3_config.sh -u ${RHCOS_IMAGE_URL} -i ${INTERNAL_NIC} > assets/deploy/99-metal3-config-map.yaml
 ${OPENSHIFT_INSTALLER} --dir ocp --log-level=${LOGLEVEL} create manifests
 for file in $(find assets/deploy/ -iname '*.yaml' -type f -printf "%P\n"); do

--- a/OpenShift/03_create_cluster.sh
+++ b/OpenShift/03_create_cluster.sh
@@ -103,6 +103,12 @@ if [[ "${PULL_SECRET}" != *"cloud.openshift.com"* ]]; then
     exit 1
 fi
 
+if [[ ${CACHE_IMAGES^^} != "FALSE" ]]
+then
+    ./cache_images.sh
+fi
+
+
 mkdir -p ocp
 extract_oc ${OPENSHIFT_RELEASE_IMAGE}
 extract_installer "${OPENSHIFT_RELEASE_IMAGE}" ocp/

--- a/OpenShift/03_create_cluster.sh
+++ b/OpenShift/03_create_cluster.sh
@@ -103,6 +103,9 @@ if [[ "${PULL_SECRET}" != *"cloud.openshift.com"* ]]; then
     exit 1
 fi
 
+# Discover and set RHCOS_IMAGE_URL
+rhcos_image_url
+
 if [[ ${CACHE_IMAGES^^} != "FALSE" ]]
 then
     ./cache_images.sh
@@ -113,7 +116,6 @@ mkdir -p ocp
 extract_oc ${OPENSHIFT_RELEASE_IMAGE}
 extract_installer "${OPENSHIFT_RELEASE_IMAGE}" ocp/
 cp install-config.yaml ocp/
-rhcos_image_url
 ./gen_metal3_config.sh -u ${RHCOS_IMAGE_URL} -i ${INTERNAL_NIC} > assets/deploy/99-metal3-config-map.yaml
 ${OPENSHIFT_INSTALLER} --dir ocp --log-level=${LOGLEVEL} create manifests
 for file in $(find assets/deploy/ -iname '*.yaml' -type f -printf "%P\n"); do

--- a/OpenShift/03_create_cluster.sh
+++ b/OpenShift/03_create_cluster.sh
@@ -118,7 +118,7 @@ fi
 
 
 cp install-config.yaml ocp/
-get_provinsion_if
+get_provision_if
 ./gen_metal3_config.sh -u ${RHCOS_IMAGE_URL} -i ${INTERNAL_NIC} > assets/deploy/99-metal3-config-map.yaml
 ${OPENSHIFT_INSTALLER} --dir ocp --log-level=${LOGLEVEL} create manifests
 for file in $(find assets/deploy/ -iname '*.yaml' -type f -printf "%P\n"); do

--- a/OpenShift/cache_images.sh
+++ b/OpenShift/cache_images.sh
@@ -8,12 +8,12 @@ source common.sh
 # Either pull or build the ironic images
 # To build the IRONIC image set
 # IRONIC_IMAGE=https://github.com/metalkube/metalkube-ironic
-for IMAGE_VAR in IRONIC_IMAGE IRONIC_INSPECTOR_IMAGE COREOS_DOWNLOADER_IMAGE ; do
+for IMAGE_VAR in IRONIC_IMAGE COREOS_DOWNLOADER_IMAGE ; do
     IMAGE=${!IMAGE_VAR}
     sudo podman pull "$IMAGE"
 done
 
-for name in ironic ironic-api ironic-conductor ironic-inspector dnsmasq httpd mariadb coreos-downloader; do
+for name in httpd coreos-downloader; do
     sudo podman ps | grep -w "$name$" && sudo podman kill $name
     sudo podman ps --all | grep -w "$name$" && sudo podman rm $name -f
 done
@@ -29,14 +29,14 @@ sudo podman pod create -n ironic-pod
 # We start only the httpd and *downloader containers so that we can provide
 # cached images to the bootstrap VM
 sudo podman run -d --net host --privileged --name httpd --pod ironic-pod \
-     -v $IRONIC_DATA_DIR:/shared --entrypoint /bin/runhttpd ${IRONIC_IMAGE}
+     -v ${CACHED_IMAGE_DIR}:/shared --entrypoint /bin/runhttpd ${IRONIC_IMAGE}
 
 sudo podman run -d --net host --privileged --name coreos-downloader --pod ironic-pod \
-     -v $IRONIC_DATA_DIR:/shared ${COREOS_DOWNLOADER_IMAGE} /usr/local/bin/get-resource.sh $RHCOS_IMAGE_URL
+     -v ${CACHED_IMAGE_DIR}:/shared ${COREOS_DOWNLOADER_IMAGE} /usr/local/bin/get-resource.sh ${RHCOS_IMAGE_URL}
 
 # Wait for the downloader containers to finish, if they are updating an existing cache
 # the checks below will pass because old data exists
 sudo podman wait -i 1000 coreos-downloader
 
 # Wait for images to be downloaded/ready
-while ! curl --fail http://localhost/images/rhcos-ootpa-latest.qcow2.md5sum ; do sleep 1 ; done
+while ! curl --fail http://localhost/images/rhcos-ootpa-latest.qcow2.md5sum ; do sleep 5 ; done

--- a/OpenShift/cache_images.sh
+++ b/OpenShift/cache_images.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -ex
+
+source ../common/logging.sh
+source common.sh
+
+# Either pull or build the ironic images
+# To build the IRONIC image set
+# IRONIC_IMAGE=https://github.com/metalkube/metalkube-ironic
+for IMAGE_VAR in IRONIC_IMAGE IRONIC_INSPECTOR_IMAGE IPA_DOWNLOADER_IMAGE COREOS_DOWNLOADER_IMAGE ; do
+    IMAGE=${!IMAGE_VAR}
+    sudo podman pull "$IMAGE"
+done
+
+for name in ironic ironic-api ironic-conductor ironic-inspector dnsmasq httpd mariadb ipa-downloader coreos-downloader; do
+    sudo podman ps | grep -w "$name$" && sudo podman kill $name
+    sudo podman ps --all | grep -w "$name$" && sudo podman rm $name -f
+done
+
+# Remove existing pod
+if  sudo podman pod exists ironic-pod ; then 
+    sudo podman pod rm ironic-pod -f
+fi
+
+# Create pod
+sudo podman pod create -n ironic-pod 
+
+# We start only the httpd and *downloader containers so that we can provide
+# cached images to the bootstrap VM
+sudo podman run -d --net host --privileged --name httpd --pod ironic-pod \
+     -v $IRONIC_DATA_DIR:/shared --entrypoint /bin/runhttpd ${IRONIC_IMAGE}
+
+sudo podman run -d --net host --privileged --name ipa-downloader --pod ironic-pod \
+     -v $IRONIC_DATA_DIR:/shared ${IPA_DOWNLOADER_IMAGE} /usr/local/bin/get-resource.sh
+
+sudo podman run -d --net host --privileged --name coreos-downloader --pod ironic-pod \
+     -v $IRONIC_DATA_DIR:/shared ${COREOS_DOWNLOADER_IMAGE} /usr/local/bin/get-resource.sh $RHCOS_IMAGE_URL
+
+# Wait for the downloader containers to finish, if they are updating an existing cache
+# the checks below will pass because old data exists
+sudo podman wait -i 1000 ipa-downloader coreos-downloader
+
+# Wait for images to be downloaded/ready
+while ! curl --fail http://localhost/images/rhcos-ootpa-latest.qcow2.md5sum ; do sleep 1 ; done
+while ! curl --fail --head http://localhost/images/ironic-python-agent.initramfs ; do sleep 1; done
+while ! curl --fail --head http://localhost/images/ironic-python-agent.tar.headers ; do sleep 1; done
+while ! curl --fail --head http://localhost/images/ironic-python-agent.kernel ; do sleep 1; done

--- a/OpenShift/cache_images.sh
+++ b/OpenShift/cache_images.sh
@@ -8,12 +8,12 @@ source common.sh
 # Either pull or build the ironic images
 # To build the IRONIC image set
 # IRONIC_IMAGE=https://github.com/metalkube/metalkube-ironic
-for IMAGE_VAR in IRONIC_IMAGE IRONIC_INSPECTOR_IMAGE IPA_DOWNLOADER_IMAGE COREOS_DOWNLOADER_IMAGE ; do
+for IMAGE_VAR in IRONIC_IMAGE IRONIC_INSPECTOR_IMAGE COREOS_DOWNLOADER_IMAGE ; do
     IMAGE=${!IMAGE_VAR}
     sudo podman pull "$IMAGE"
 done
 
-for name in ironic ironic-api ironic-conductor ironic-inspector dnsmasq httpd mariadb ipa-downloader coreos-downloader; do
+for name in ironic ironic-api ironic-conductor ironic-inspector dnsmasq httpd mariadb coreos-downloader; do
     sudo podman ps | grep -w "$name$" && sudo podman kill $name
     sudo podman ps --all | grep -w "$name$" && sudo podman rm $name -f
 done
@@ -31,18 +31,12 @@ sudo podman pod create -n ironic-pod
 sudo podman run -d --net host --privileged --name httpd --pod ironic-pod \
      -v $IRONIC_DATA_DIR:/shared --entrypoint /bin/runhttpd ${IRONIC_IMAGE}
 
-sudo podman run -d --net host --privileged --name ipa-downloader --pod ironic-pod \
-     -v $IRONIC_DATA_DIR:/shared ${IPA_DOWNLOADER_IMAGE} /usr/local/bin/get-resource.sh
-
 sudo podman run -d --net host --privileged --name coreos-downloader --pod ironic-pod \
      -v $IRONIC_DATA_DIR:/shared ${COREOS_DOWNLOADER_IMAGE} /usr/local/bin/get-resource.sh $RHCOS_IMAGE_URL
 
 # Wait for the downloader containers to finish, if they are updating an existing cache
 # the checks below will pass because old data exists
-sudo podman wait -i 1000 ipa-downloader coreos-downloader
+sudo podman wait -i 1000 coreos-downloader
 
 # Wait for images to be downloaded/ready
 while ! curl --fail http://localhost/images/rhcos-ootpa-latest.qcow2.md5sum ; do sleep 1 ; done
-while ! curl --fail --head http://localhost/images/ironic-python-agent.initramfs ; do sleep 1; done
-while ! curl --fail --head http://localhost/images/ironic-python-agent.tar.headers ; do sleep 1; done
-while ! curl --fail --head http://localhost/images/ironic-python-agent.kernel ; do sleep 1; done

--- a/OpenShift/common.sh
+++ b/OpenShift/common.sh
@@ -43,3 +43,31 @@ if [ ${#PULL_SECRET} = 0 ]; then
   echo "Get a valid pull secret (json string) from https://cloud.openshift.com/clusters/install#pull-secret"
   exit 1
 fi
+
+
+WORKING_DIR=${WORKING_DIR:-"/opt/dev-scripts"}
+# Ironic vars
+export IRONIC_IMAGE=${IRONIC_IMAGE:-"quay.io/metal3-io/ironic:master"}
+export IRONIC_INSPECTOR_IMAGE=${IRONIC_INSPECTOR_IMAGE:-"quay.io/metal3-io/ironic-inspector:master"}
+export IPA_DOWNLOADER_IMAGE=${IPA_DOWNLOADER_IMAGE:-"quay.io/metal3-io/ironic-ipa-downloader:master"}
+export COREOS_DOWNLOADER_IMAGE=${COREOS_DOWNLOADER_IMAGE:-"quay.io/openshift-metal3/rhcos-downloader:master"}
+export IRONIC_DATA_DIR="$WORKING_DIR/ironic"
+
+export KUBECONFIG="${SCRIPTDIR}/ocp/auth/kubeconfig"
+
+# Use a cloudy ssh that doesn't do Host Key checking
+export SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5"
+
+if [ ! -d "$WORKING_DIR" ]; then
+  echo "Creating Working Dir"
+  sudo mkdir "$WORKING_DIR"
+  sudo chown "${USER}:${USER}" "$WORKING_DIR"
+  chmod 755 "$WORKING_DIR"
+fi
+
+if [ ! -d "$IRONIC_DATA_DIR" ]; then
+  echo "Creating Ironic Data Dir"
+  sudo mkdir "$IRONIC_DATA_DIR"
+  sudo chown "${USER}:${USER}" "$IRONIC_DATA_DIR"
+  chmod 755 "$IRONIC_DATA_DIR"
+fi

--- a/OpenShift/common.sh
+++ b/OpenShift/common.sh
@@ -45,7 +45,7 @@ if [ ${#PULL_SECRET} = 0 ]; then
 fi
 
 
-WORKING_DIR=${WORKING_DIR:-"/opt/dev-scripts"}
+WORKING_DIR=${WORKING_DIR:-"/opt/install-scripts"}
 # Ironic vars
 export IRONIC_IMAGE=${IRONIC_IMAGE:-"quay.io/metal3-io/ironic:master"}
 export IRONIC_INSPECTOR_IMAGE=${IRONIC_INSPECTOR_IMAGE:-"quay.io/metal3-io/ironic-inspector:master"}

--- a/OpenShift/common.sh
+++ b/OpenShift/common.sh
@@ -19,7 +19,7 @@ source $CONFIG
 
 # Connect to system libvirt
 export LIBVIRT_DEFAULT_URI=qemu:///system
-if [ "$USER" != "root" -a "${XDG_RUNTIME_DIR:-}" == "/run/user/0" ] ; then
+if [ "${USER}" != "root" -a "${XDG_RUNTIME_DIR:-}" == "/run/user/0" ] ; then
     echo "Please use a non-root user, WITH a login shell (e.g. su - USER)"
     exit 1
 fi
@@ -45,29 +45,17 @@ if [ ${#PULL_SECRET} = 0 ]; then
 fi
 
 
-WORKING_DIR=${WORKING_DIR:-"/opt/install-scripts"}
 # Ironic vars
 export IRONIC_IMAGE=${IRONIC_IMAGE:-"quay.io/metal3-io/ironic:master"}
-export IRONIC_INSPECTOR_IMAGE=${IRONIC_INSPECTOR_IMAGE:-"quay.io/metal3-io/ironic-inspector:master"}
-export IPA_DOWNLOADER_IMAGE=${IPA_DOWNLOADER_IMAGE:-"quay.io/metal3-io/ironic-ipa-downloader:master"}
 export COREOS_DOWNLOADER_IMAGE=${COREOS_DOWNLOADER_IMAGE:-"quay.io/openshift-metal3/rhcos-downloader:master"}
-export IRONIC_DATA_DIR="$WORKING_DIR/ironic"
+export CACHED_IMAGE_DIR="${SCRIPTDIR}/cache"
 
 export KUBECONFIG="${SCRIPTDIR}/ocp/auth/kubeconfig"
 
-# Use a cloudy ssh that doesn't do Host Key checking
-export SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5"
 
-if [ ! -d "$WORKING_DIR" ]; then
-  echo "Creating Working Dir"
-  sudo mkdir "$WORKING_DIR"
-  sudo chown "${USER}:${USER}" "$WORKING_DIR"
-  chmod 755 "$WORKING_DIR"
-fi
-
-if [ ! -d "$IRONIC_DATA_DIR" ]; then
-  echo "Creating Ironic Data Dir"
-  sudo mkdir "$IRONIC_DATA_DIR"
-  sudo chown "${USER}:${USER}" "$IRONIC_DATA_DIR"
-  chmod 755 "$IRONIC_DATA_DIR"
+if [ ! -d "${CACHED_IMAGE_DIR}" ]; then
+  echo "Creating Cached Data Dir"
+  sudo mkdir "${CACHED_IMAGE_DIR}"
+  sudo chown "${USER}:${USER}" "${CACHED_IMAGE_DIR}"
+  chmod 755 "${CACHED_IMAGE_DIR}"
 fi

--- a/OpenShift/config_example.sh
+++ b/OpenShift/config_example.sh
@@ -17,3 +17,6 @@ set -x
 
 # Set loglevel for OpenShift installation
 #LOGLEVEL=debug
+
+# Aviod caching of the RHCOS image
+#CACHE_IMAGES=false

--- a/OpenShift/gen_metal3_config.sh
+++ b/OpenShift/gen_metal3_config.sh
@@ -7,7 +7,7 @@ script_name=$0
 RHCOS_IMAGE_URL=""
 PROVISIONING_INTERFACE="eno1"
 PROVISIONING_ADDRESS="172.22.0.3"
-CACHE_URL="http://172.22.0.2/images"
+CACHE_URL="http://172.22.0.1/images"
 
 function usage {
     cat - <<EOF
@@ -20,7 +20,7 @@ $script_name [-h|-u URL [-i INTERFACE] [-a IPADDR] [-c CACHE_URL]]
                   Defaults to "eno1".
     -u URL        Specify the RHCOS image URL to use to prime the cache.
     -c CACHE_URL  Specify a cache URL where the image can be downloaded
-                  Defaults to http://172.22.0.2/images.
+                  Defaults to http://172.22.0.1/images.
 
 EOF
 }


### PR DESCRIPTION
fixes #67 Download rhcos and ironic python agent images on provision host first


This does download the RHCOS but saw in the discussion  of #67 that it looked like IPA did not need to be cached any longer.

This required port 80 or service http is open.   The has been done in the latest ISO.