### PR TITLE
Use just x.y notation for CNV channel names

### DIFF
--- a/CNV/cnv-2.1.0.sh
+++ b/CNV/cnv-2.1.0.sh
@@ -15,6 +15,7 @@ CLUSTER="${CLUSTER:-OPENSHIFT}"
 MARKETPLACE_NAMESPACE="${MARKETPLACE_NAMESPACE:-openshift-marketplace}"
 GLOBAL_NAMESPACE="${GLOBAL_NAMESPACE:-$globalNamespace}"
 CNV_VERSION="${CNV_VERSION:-2.1.0}"
+CNV_CHANNEL="${CNV_VERSION:0:3}"
 QUAY_TOKEN="${QUAY_TOKEN:-}"
 APPROVAL="${APPROVAL:-Manual}"
 
@@ -137,7 +138,7 @@ spec:
   sourceNamespace: "${GLOBAL_NAMESPACE}"
   name: kubevirt-hyperconverged
   startingCSV: "kubevirt-hyperconverged-operator.v${CNV_VERSION}"
-  channel: "${CNV_VERSION}"
+  channel: "${CNV_CHANNEL}"
   installPlanApproval: "${APPROVAL}"
 EOF
 

--- a/CNV/cnv-upgrade.sh
+++ b/CNV/cnv-upgrade.sh
@@ -2,17 +2,19 @@
 
 set -ex
 
-OLD_CNV_VERSION="${CNV_VERSION:-2.0.0}"
+OLD_CNV_VERSION="${OLD_CNV_VERSION:-2.0.0}"
 CNV_VERSION="${CNV_VERSION:-2.1.0}"
+OLD_CNV_CHANNEL="${OLD_CNV_VERSION:0:3}"
+CNV_CHANNEL="${CNV_VERSION:0:3}"
 TARGET_NAMESPACE="${TARGET_NAMESPACE:-openshift-cnv}"
 
-oc get sub hco-subscription -o yaml -n "${TARGET_NAMESPACE}" | sed "s/channel: ${OLD_CNV_VERSION}/channel: ${CNV_VERSION}/" | oc apply -n "${TARGET_NAMESPACE}" -f -
+oc get sub hco-subscription -o yaml -n "${TARGET_NAMESPACE}" | sed "s/channel: ${OLD_CNV_CHANNEL}/channel: ${CNV_CHANNEL}/" | oc apply -n "${TARGET_NAMESPACE}" -f -
 
 oc get installplan -o yaml -n "${TARGET_NAMESPACE}" $(oc get installplan -n "${TARGET_NAMESPACE}" --no-headers | grep kubevirt-hyperconverged-operator.v"${CNV_VERSION}" | awk '{print $1}') | sed 's/approved: false/approved: true/' | oc apply -n "${TARGET_NAMESPACE}" -f -
 
 echo "Waiting until OLM replaces the ${OLD_CNV_VERSION} CSV"
 echo "This could take up to 10 minutes..."
-while [ -z "$(oc get csv -o'custom-columns=status:status.conditions[-1].phase,metadata:metadata.name' --no-headers | grep kubevirt-hyperconverged-operator.v${CSV_VERSION} | grep Succeeded)" ]; do
+while [ -z "$(oc get csv -o'custom-columns=status:status.conditions[-1].phase,metadata:metadata.name' --no-headers | grep kubevirt-hyperconverged-operator.v${CNV_VERSION} | grep Succeeded)" ]; do
     echo "Waiting for ${CNV_VERSION} CSV to be in 'Succeeded'..."
     oc get csv -o'custom-columns=status:status.conditions[-1].phase,metadata:metadata.name' --no-headers | grep kubevirt-hyperconverged-operator
     sleep 30


### PR DESCRIPTION
Use 2.1 as the channel name instead of 2.1.0
to enable smooth z-stream updates inside the same
channel.