### PR TITLE
Fix Multiple Use Cases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ prep:
 	set -e; pushd OpenShift; make pre_install; popd
 
 preflight:
-	set -e; pushd preflight; sudo ./preflight.sh -d; cp config_${USER}.sh install-config.yaml ../OpenShift/; popd
+	set -e; pushd preflight; sudo ./preflight.sh -d -o; cp config_${USER}.sh install-config.yaml ../OpenShift/; popd
 
 OpenShift:
 	set -e; pushd OpenShift; make; popd

--- a/preflight/host_patch.j2
+++ b/preflight/host_patch.j2
@@ -5,9 +5,9 @@
       "nics": [
         {
           "ip": "${ipaddr}",
-          "mac": "{{ hardware_json.ansible_facts.redfish_facts.nic.entries[0][1][3].PermanentMACAddress }}",
-          "model": "{{ hardware_json.ansible_facts.redfish_facts.nic.entries[0][1][3].Description }}",
-          "speedGbps": {{ hardware_json.ansible_facts.redfish_facts.nic.entries[0][1][3].SpeedMbps / 1024 }},
+          "mac": "{{ hardware_json.ansible_facts.redfish_facts.nic.entries[0][1][nicnum].PermanentMACAddress }}",
+          "model": "{{ hardware_json.ansible_facts.redfish_facts.nic.entries[0][1][nicnum].Description }}",
+          "speedGbps": {{ hardware_json.ansible_facts.redfish_facts.nic.entries[0][1][nicnum].SpeedMbps / 1024 }},
           "vlanId": 0,
           "pxe": true,
           "name": "eno1"
@@ -31,7 +31,7 @@
         "arch": "x86_64",
         "model": "{{ hardware_json.ansible_facts.redfish_facts.system.entries[0][1].ProcessorSummary.Model }}",
         "clockMegahertz": {{ hardware_json.ansible_facts.redfish_facts.bios_attribute.entries[0][1].ProcCoreSpeed.split(" ")[0] | float * 1024 }},
-        "count": {{ hardware_json.ansible_facts.redfish_facts.system.entries[0][1].ProcessorSummary.LogicalProcessorCount }},
+        "count": {{ hardware_json.ansible_facts.redfish_facts.system.entries[0][1].ProcessorSummary.LogicalProcessorCount | default(0) }},
         "flags": []
       }
     }

--- a/preflight/preflight.sh
+++ b/preflight/preflight.sh
@@ -12,13 +12,14 @@
 source ../common/logging.sh
 
 howto(){
-  echo "Usage: preflight.sh -u username -p password -m master-0-ip,master-1-ip,master-2-ip -w worker-0-ip,worker-1-ip"
+  echo "Usage: preflight.sh -u username -p password -m master-0-ip,master-1-ip,master-2-ip -w worker-0-ip,worker-1-ip -o (power off nodes)"
   echo "Example: preflight.sh -u root -p calvin -m 172.22.0.231,172.22.0.232,172.22.0.233 -w 172.22.0.234"
   echo "Example: preflight.sh -u root -p calvin -d (use default settings where switches are not specified)"
 }
 
 df=0
-while getopts u:p:m:w:dh option
+power=0
+while getopts u:p:m:w:doh option
 do
 case "${option}"
 in
@@ -27,6 +28,7 @@ p) dracpassword=${OPTARG};;
 m) mip=${OPTARG};;
 w) wip=${OPTARG};;
 d) df=1;;
+o) power=1;;
 h) howto; exit 0;;
 \?) howto; exit 1;;
 esac
@@ -66,6 +68,13 @@ if ([ -z "$wip" ] && [ "$df" -eq "1" ]) then
    wip="172.22.0.234"
 fi
 
+if ([ "$power" -eq "1" ]) then
+   export power
+   powerstatus="Nodes will be powered off before deployment..."
+else
+   powerstatus="Nodes will not be powered off before deployment..."
+fi
+
 if ([ "$df" -eq "1" ]) then
    dfstatus="Using defaults where no arguments provided..."
 else
@@ -90,6 +99,7 @@ fi
 ##################################################################
 
 echo $dfstatus
+echo $powerstatus
 echo -n Discovering Cluster Name and Domain...
 bootstrapip=`ip addr show baremetal| grep 'inet ' | cut -d/ -f1 | awk '{ print $2}'`
 dnsname=`nslookup $bootstrapip|grep name| cut -d= -f2|sed s'/^ //'g|sed s'/.$//g'`

--- a/preflight/redfish.yml
+++ b/preflight/redfish.yml
@@ -61,7 +61,7 @@
         dhcpipnet=`/usr/bin/ipcalc -n $dhcpip/$extcidr |cut -f2 -d=`
         extipnet=`/usr/bin/ipcalc -n $extip/$extcidr |cut -f2 -d=`
         if [ $dhcpip == $extip ] && [ $dhcpipnet == $extipnet ] && [ $extnet == $extipnet ]; then dnstat="Success"; else dnstat="Failed"; fi
-        if (echo "{{ inventory_hostname }}"|grep -q master); then echo "{{ inventory_hostname }} name={{ inventory_hostname }} role=master ipmi_username={{ bmcuser }} ipmi_password={{ bmcpassword }} ipmi_address={{ bmcip }} mac=$macaddress disk=59">>hosts; fi
+        if (echo "{{ inventory_hostname }}"|grep -q master); then echo "{{ inventory_hostname }} name={{ inventory_hostname }} role=master ipmi_username={{ bmcuser }} ipmi_password={{ bmcpassword }} ipmi_address={{ bmcip }} mac=$macaddress disk=59 nicnum=$nicnum">>hosts; fi
         if (echo "{{ inventory_hostname }}"|grep -q worker-0); then intip=`ip -f inet a show provisioning|sed -En -e 's/.*inet ([0-9.]+).*/\1/p'`; fi
         cat << EOF >> dhcps
         {{ inventory_hostname }}.{{ cluster }}.{{ domain }}  $extmacaddress  $extip  External  $dnstat

--- a/preflight/redfish.yml
+++ b/preflight/redfish.yml
@@ -53,6 +53,7 @@
         intip="Unassigned"
         macaddress=`jq -r '.ansible_facts.redfish_facts.nic.entries[0][1][]|select(.Description=="Integrated NIC 1 Port 1 Partition 1")|.PermanentMACAddress' {{inventory_hostname}}.hwprofile.json`
         extmacaddress=`jq -r '.ansible_facts.redfish_facts.nic.entries[0][1][]|select(.Description=="Integrated NIC 1 Port 2 Partition 1")|.PermanentMACAddress' {{inventory_hostname}}.hwprofile.json`
+        nicnum=`grep NIC {{inventory_hostname}}.hwprofile.json | grep Description| grep -Fn "Integrated NIC 1 Port 1 Partition 1"|awk -F: {'print $1'} | awk '{print $0-1}'`
         dhcpip=`./check_dhcp.py -m $extmacaddress|grep Offered|cut -f2 -d:|sed "s/ //g"`
         extip=`getent hosts {{ inventory_hostname }}.{{ cluster }}.{{ domain }}|awk {'print $1'}`
         extnet=`/usr/bin/ipcalc -n "$(/usr/sbin/ip -o addr show|grep baremetal|grep -v inet6|awk {'print $4'})"|cut -f2 -d=`
@@ -85,3 +86,4 @@
         password: "{{ ipmi_password }}"
       delegate_to: localhost
       ignore_errors: true
+      when: lookup('env','power') == '1'


### PR DESCRIPTION
-Created option -o to power off nodes otherwise they are left on by default - useful for testing
-Enabled dynamic Redfish discovery of 1st integrated nic instead of it being hard coded  - useful for different hardware nic configurations
-When LogicalProcessCount is missing in RedFish will default to 0 - This seems to be an issue on older Dell hardware