### PR TITLE
Rewrite `while read` to `for` loop.

### DIFF
--- a/OpenShift/03_create_cluster.sh
+++ b/OpenShift/03_create_cluster.sh
@@ -72,7 +72,7 @@ function rhcos_image_url() {
 function get_provision_if() {
   #Dont do anything if there is a value already set
   if [[ -z "${INTERNAL_NIC}" ]]; then
-    lshw -quiet -class network | grep -A 1 "bus info" | grep name | awk -F': ' '{print $2}'|grep e | while read interface; do
+    for interface in $( sudo lshw -quiet -class network | grep -A 1 "bus info" | grep name | awk -F': ' '{print $2}'|grep e ); do
       if (`ip a|grep $interface|grep provisioning>/dev/null 2>&1`); then
         INTERNAL_NIC="$interface"
       fi


### PR DESCRIPTION
Running `while read` loop blocks INTERNAL_NIC variable propagation
to the main program, that results in next error message:

```
  ++ ip a
  ++ grep eno1
  ++ grep provisioning
  + INTERNAL_NIC=eno1
  + read interface
  ++ ip a
  ++ grep eno2
  ++ grep provisioning
  + read interface
  + ./gen_metal3_config.sh -u some-image-openstack.qcow2 -i
  ./gen_metal3_config.sh: option requires an argument -- i
```

Also added sudo to `lshw` command to avoid warning:
```
  WARNING: you should run this program as super-user.
  WARNING: output may be incomplete or inaccurate, you should run this program as super-user.
```