### PR TITLE
Add support for multiple insecure registries.

### DIFF
--- a/OpenShift/99_post_install.sh
+++ b/OpenShift/99_post_install.sh
@@ -19,8 +19,17 @@ apply_mc(){
   # Add extra registry if needed (this applies clusterwide)
   # https://docs.openshift.com/container-platform/4.1/openshift_images/image-configuration.html#images-configuration-insecure_image-configuration
   if [ "${EXTRA_REGISTRY}" != "" ] ; then
-    echo "Adding ${EXTRA_REGISTRY}..."
-    oc patch image.config.openshift.io/cluster --type merge --patch "{\"spec\":{\"registrySources\":{\"insecureRegistries\":[\"${EXTRA_REGISTRY}\"]}}}"
+    _registry=''
+    _oldifs=${IFS}
+    IFS=';'
+
+    for i in ${EXTRA_REGISTRY};do
+        echo "Adding ${_registry}..."
+        _registry="${_registry},\"${i}\""
+    done
+
+    oc patch image.config.openshift.io/cluster --type merge --patch "{\"spec\":{\"registrySources\":{\"insecureRegistries\":[${_registry#,}]}}}"
+    IFS=${_oldifs}
   fi
 
   # Apply machine configs


### PR DESCRIPTION
This change allows to specify multiple insecure registries, that
have to be configured on master/worker nodes.

Insecure registries have to be passed by EXTRA_REGISTRY variabled
and be separated with semicolon, for e.g.:
  EXTRA_REGISTRY="registry-1;registry-2:55;registry-3"