### PR TITLE
Adding sort to names.

### DIFF
--- a/preflight/install-config.j2
+++ b/preflight/install-config.j2
@@ -20,7 +20,7 @@ platform:
     dnsVIP: {{ hostvars[host]['ns1vip'] }}
     hosts:
 {% endfor %}
-{% for host in groups['masters'] %}
+{% for host in groups['masters']|sort %}
       - name: {{ hostvars[host]['name'] }}
         role: {{ hostvars[host]['role'] }}
         bmc:


### PR DESCRIPTION
Without this sort the names could appear
in an arbitrary order in the generated
install-config.yaml

Signed-off-by: Alexander Chuzhoy <achuzhoy@redhat.com>